### PR TITLE
Update tld.txt, .app is also a valid tld

### DIFF
--- a/gfwlist2pac/resources/tld.txt
+++ b/gfwlist2pac/resources/tld.txt
@@ -142,6 +142,7 @@ og.ao
 co.ao
 pb.ao
 it.ao
+app
 aq
 ar
 com.ar


### PR DESCRIPTION
Fix a bug that URL `*.app` not included in pac file.